### PR TITLE
fix: install and use oam_subs instead of amass db

### DIFF
--- a/pkg/passive/amass/amass.go
+++ b/pkg/passive/amass/amass.go
@@ -17,7 +17,7 @@ func RunAmass(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	if err != nil {
 		panic(err)
 	}
-	cmd = exec.Command("amass", "db", "-names", "-d", seedDomain)
+	cmd = exec.Command("oam_subs", "-names", "-d", seedDomain)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -185,28 +185,17 @@ func sendToDiscord(webhookURL string, message string) {
 }
 
 func InstallTools() {
-	if !checkTool("amass") {
-		installGoTool("amass", "github.com/owasp-amass/amass/v4/...@master")
-	}
-
-	if !checkTool("oam_subs") {
-		installGoTool("oam_subs", "github.com/owasp-amass/oam-tools/cmd/oam_subs@master")
-	}
-
-	if !checkTool("subfinder") {
-		installGoTool("subfinder", "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest")
-	}
-
-	if !checkTool("httpx") {
-		installGoTool("httpx", "github.com/projectdiscovery/httpx/cmd/httpx@latest")
-	}
-
-	if !checkTool("dnsx") {
-		installGoTool("dnsx", "github.com/projectdiscovery/dnsx/cmd/dnsx@latest")
-	}
-
-	if !checkTool("alterx") {
-		installGoTool("alterx", "github.com/projectdiscovery/alterx/cmd/alterx@latest")
+	for name, path := range map[string]string{
+		"alterx":    "github.com/projectdiscovery/alterx/cmd/alterx@latest",
+		"amass":     "github.com/owasp-amass/amass/v4/...@master",
+		"dnsx":      "github.com/projectdiscovery/dnsx/cmd/dnsx@latest",
+		"httpx":     "github.com/projectdiscovery/httpx/cmd/httpx@latest",
+		"oam_subs":  "github.com/owasp-amass/oam-tools/cmd/oam_subs@master",
+		"subfinder": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest",
+	} {
+		if !checkTool(name) {
+			installGoTool(name, path)
+		}
 	}
 
 	fmt.Println("All needed tools installed!")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -185,30 +185,30 @@ func sendToDiscord(webhookURL string, message string) {
 }
 
 func InstallTools() {
-	check := checkTool("amass")
-	if !check {
+	if !checkTool("amass") {
 		installGoTool("amass", "github.com/owasp-amass/amass/v4/...@master")
 	}
 
-	check = checkTool("subfinder")
-	if !check {
+	if !checkTool("oam_subs") {
+		installGoTool("oam_subs", "github.com/owasp-amass/oam-tools/cmd/oam_subs@master")
+	}
+
+	if !checkTool("subfinder") {
 		installGoTool("subfinder", "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest")
 	}
 
-	check = checkTool("httpx")
-	if !check {
+	if !checkTool("httpx") {
 		installGoTool("httpx", "github.com/projectdiscovery/httpx/cmd/httpx@latest")
 	}
 
-	check = checkTool("dnsx")
-	if !check {
+	if !checkTool("dnsx") {
 		installGoTool("dnsx", "github.com/projectdiscovery/dnsx/cmd/dnsx@latest")
 	}
 
-	check = checkTool("alterx")
-	if !check {
+	if !checkTool("alterx") {
 		installGoTool("alterx", "github.com/projectdiscovery/alterx/cmd/alterx@latest")
 	}
+
 	fmt.Println("All needed tools installed!")
 }
 


### PR DESCRIPTION
The [oam_subs command](https://github.com/owasp-amass/oam-tools/blob/master/user_guide.md#the-oam_subs-command) now replaces the `amass db` subcommand.