### PR TITLE
Ignore Column Names in CSV when tracking domains

### DIFF
--- a/easyeasm/main.go
+++ b/easyeasm/main.go
@@ -106,13 +106,20 @@ func main() {
 	fmt.Printf(" => Active DNS subdomains found this run: %d\n", Runner.Results)
 	// fmt.Println(Runner.Subdomains)
 	for _, domain := range Runner.Subdomains {
-		if !domainExists(db, domain) {
-			insertDomain(db, domain)
-		} else if !domainIsActive(db, domain) {
-			updateActiveDomain(db, domain, true)
-		}
-		if !contains(currentActiveDomains, domain) {
-			newActiveDomains = append(newActiveDomains, domain)
+		_, err := net.LookupHost(domain)
+		if err != nil {
+			if !domainExists(db, domain) {
+				updateActiveDomain(db, domain, false)
+			}
+		} else {
+			if !domainExists(db, domain) {
+				insertDomain(db, domain)
+			} else if !domainIsActive(db, domain) {
+				updateActiveDomain(db, domain, true)
+			}
+			if !contains(currentActiveDomains, domain) {
+				newActiveDomains = append(newActiveDomains, domain)
+			}
 		}
 	}
 

--- a/easyeasm/main.go
+++ b/easyeasm/main.go
@@ -28,6 +28,7 @@ func main() {
 
 	// parse the configuration file
 	cfg := configparser.ParseConfig()
+	fmt.Println(" => Domain(s): ", cfg.RunConfig.Domains)
 
 	// db setup
 	if _, err := os.Stat("easyeasm.db"); err == nil {

--- a/easyeasm/main.go
+++ b/easyeasm/main.go
@@ -77,6 +77,7 @@ func main() {
 			}
 		} else {
 			currentActiveDomains = append(currentActiveDomains, domain)
+			updateActiveDomain(db, domain, true)
 		}
 	}
 	for _, domain := range oldLiveDomains {
@@ -88,6 +89,12 @@ func main() {
 			updateLiveDomain(db, domain, false)
 		} else {
 			currentLiveDomains = append(currentLiveDomains, domain)
+			updateLiveDomain(db, domain, true)
+			if !contains(currentActiveDomains, domain) {
+				newActiveDomains = append(newActiveDomains, domain)
+				currentActiveDomains = append(currentActiveDomains, domain)
+				updateActiveDomain(db, domain, true)
+			}
 		}
 	}
 
@@ -138,11 +145,21 @@ func main() {
 				insertDomain(db, domain)
 				updateLiveDomain(db, domain, true)
 			}
-			if !domainIsLive(db, domain) {
+			_, err1 := client.Get("http://" + domain)
+			_, err2 := client.Get("https://" + domain)
+			if err1 != nil && err2 != nil {
+				updateLiveDomain(db, domain, false)
+			} else {
+				if !contains(currentLiveDomains, domain) {
+					newLiveDomains = append(newLiveDomains, domain)
+					currentLiveDomains = append(currentLiveDomains, domain)
+				}
+				if !contains(currentActiveDomains, domain) {
+					newActiveDomains = append(newActiveDomains, domain)
+					currentActiveDomains = append(currentActiveDomains, domain)
+					updateActiveDomain(db, domain, true)
+				}
 				updateLiveDomain(db, domain, true)
-			}
-			if !contains(currentLiveDomains, domain) {
-				newLiveDomains = append(newLiveDomains, domain)
 			}
 		}
 
@@ -183,6 +200,11 @@ func main() {
 				if !contains(currentLiveDomains, domain) {
 					newLiveDomains = append(newLiveDomains, domain)
 					currentLiveDomains = append(currentLiveDomains, domain)
+				}
+				if !contains(currentActiveDomains, domain) {
+					newActiveDomains = append(newActiveDomains, domain)
+					currentActiveDomains = append(currentActiveDomains, domain)
+					updateActiveDomain(db, domain, true)
 				}
 				updateLiveDomain(db, domain, true)
 			}

--- a/easyeasm/main.go
+++ b/easyeasm/main.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/g0ldencybersec/EasyEASM/pkg/active"
-	"github.com/g0ldencybersec/EasyEASM/pkg/configparser"
-	"github.com/g0ldencybersec/EasyEASM/pkg/passive"
-	"github.com/g0ldencybersec/EasyEASM/pkg/utils"
+	"github.com/sethlaw/EasyEASM/pkg/active"
+	"github.com/sethlaw/EasyEASM/pkg/configparser"
+	"github.com/sethlaw/EasyEASM/pkg/passive"
+	"github.com/sethlaw/EasyEASM/pkg/utils"
 )
 
 func main() {
@@ -103,6 +103,11 @@ func main() {
 		// httpx scan
 		fmt.Printf("Found %d subdomains: ", ActiveRunner.Results)
 		fmt.Println(ActiveRunner.Subdomains)
+		if !prevRun {
+			for _, domain := range ActiveRunner.Subdomains {
+				utils.insertDomain(domain, "./easyeasm.db")
+			}
+		}
 		fmt.Println("Checking which domains are live and generating assets csv...")
 		ActiveRunner.RunHttpx()
 

--- a/easyeasm/main.go
+++ b/easyeasm/main.go
@@ -31,8 +31,11 @@ func main() {
 		if e != nil {
 			panic(e)
 		}
+		var domains = utils.getActiveDomains("./easyeasm.db")
+		fmt.Println("Active domains from previous run: ", len(domains))
 	} else {
 		fmt.Println("No previous run data found")
+		utils.setupDB()
 		prevRun = false
 	}
 
@@ -63,9 +66,11 @@ func main() {
 		if prevRun && strings.Contains(cfg.RunConfig.SlackWebhook, "https") {
 			utils.NotifyNewDomainsSlack(Runner.Subdomains, cfg.RunConfig.SlackWebhook)
 			os.Remove("old_EasyEASM.csv")
+			os.Remove("old_tracked.csv")
 		} else if prevRun && strings.Contains(cfg.RunConfig.DiscordWebhook, "https") {
 			utils.NotifyNewDomainsDiscord(Runner.Subdomains, cfg.RunConfig.DiscordWebhook)
 			os.Remove("old_EasyEASM.csv")
+			os.Remove("old_tracked.csv")
 		}
 	} else if strings.ToLower(cfg.RunConfig.RunType) == "complete" {
 		// complete run: passive and active enumeration
@@ -96,7 +101,7 @@ func main() {
 		ActiveRunner.Results = len(ActiveRunner.Subdomains)
 
 		// httpx scan
-		fmt.Printf("Found %d subdomains\n\n", ActiveRunner.Results)
+		fmt.Printf("Found %d subdomains: ", ActiveRunner.Results)
 		fmt.Println(ActiveRunner.Subdomains)
 		fmt.Println("Checking which domains are live and generating assets csv...")
 		ActiveRunner.RunHttpx()
@@ -105,9 +110,11 @@ func main() {
 		if prevRun && strings.Contains(cfg.RunConfig.SlackWebhook, "https") {
 			utils.NotifyNewDomainsSlack(ActiveRunner.Subdomains, cfg.RunConfig.SlackWebhook)
 			os.Remove("old_EasyEASM.csv")
+			os.Remove("old_tracked.csv")
 		} else if prevRun && strings.Contains(cfg.RunConfig.DiscordWebhook, "https") {
 			utils.NotifyNewDomainsDiscord(ActiveRunner.Subdomains, cfg.RunConfig.DiscordWebhook)
 			os.Remove("old_EasyEASM.csv")
+			os.Remove("old_tracked.csv")
 		}
 	} else {
 		// invalid run mode specified

--- a/easyeasm/main.go
+++ b/easyeasm/main.go
@@ -22,7 +22,7 @@ func main() {
 	utils.InstallTools()
 
 	// print a banner
-	banner := "****************\n\nEASY EASM\n\n***************\n"
+	banner := "-----------------------------\n      EASY EASM\n-----------------------------"
 	fmt.Println(banner)
 
 	// parse the configuration file
@@ -67,7 +67,7 @@ func main() {
 	Runner.Results = len(Runner.Subdomains)
 
 	fmt.Printf("Active DNS subdomains found this run: %d\n", Runner.Results)
-	fmt.Println(Runner.Subdomains)
+	// fmt.Println(Runner.Subdomains)
 	for _, domain := range Runner.Subdomains {
 		if !domainExists(db, domain) {
 			insertDomain(db, domain)
@@ -98,7 +98,7 @@ func main() {
 		Runner.RunHttpx()
 		fmt.Println("Number of live subdomain hosts: ", len(Runner.Subdomains))
 
-		fmt.Println("Live subdomain hosts: ", Runner.Subdomains)
+		// fmt.Println("Live subdomain hosts: ", Runner.Subdomains)
 		for _, domain := range Runner.Subdomains {
 			if !domainExists(db, domain) {
 				insertDomain(db, domain)
@@ -143,7 +143,7 @@ func main() {
 
 		// httpx scan
 		fmt.Printf("Found %d live subdomains: ", ActiveRunner.Results)
-		fmt.Println(ActiveRunner.Subdomains)
+		// fmt.Println(ActiveRunner.Subdomains)
 		fmt.Println("Checking which domains are live and generating assets csv...")
 		ActiveRunner.RunHttpx()
 		for _, domain := range ActiveRunner.Subdomains {
@@ -166,6 +166,7 @@ func main() {
 		}
 
 		fmt.Println("Number of new live subdomain hosts: ", len(newLiveDomains))
+		// fmt.Println(newLiveDomains)
 
 		// notify about new domains
 		notifyDomains(newActiveDomains, newLiveDomains, deprecatedActiveDomains, deprecatedLiveDomains, cfg.RunConfig.SlackWebhook)
@@ -174,6 +175,7 @@ func main() {
 		panic("Please pick a valid run mode and add it to your config.yml file! You can set runType to either 'fast' or 'complete'")
 	}
 	db.Close() // Close the SQLite File
+	fmt.Println("-----------------------------")
 }
 
 func notifyDomains(newActiveDomains []string, newLiveDomains []string, deprecatedActiveDomains []string, deprecatedLiveDomains []string, slackWebhook string) {

--- a/easyeasm/main.go
+++ b/easyeasm/main.go
@@ -84,6 +84,8 @@ func main() {
 			fmt.Println("Deprecated active domain: ", domain)
 			deprecatedActiveDomains = append(deprecatedActiveDomains, domain)
 			updateActiveDomain(db, domain, false)
+		} else {
+			newActiveDomains = remove(newActiveDomains, domain)
 		}
 	}
 
@@ -109,6 +111,8 @@ func main() {
 				fmt.Println("Deprecated live domain: ", domain)
 				deprecatedLiveDomains = append(deprecatedLiveDomains, domain)
 				updateLiveDomain(db, domain, false)
+			} else {
+				newLiveDomains = remove(newLiveDomains, domain)
 			}
 		}
 
@@ -151,6 +155,8 @@ func main() {
 				fmt.Println("Deprecated live domain: ", domain)
 				deprecatedLiveDomains = append(deprecatedLiveDomains, domain)
 				updateLiveDomain(db, domain, false)
+			} else {
+				newLiveDomains = remove(newLiveDomains, domain)
 			}
 		}
 
@@ -327,6 +333,15 @@ func contains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func remove[T comparable](l []T, item T) []T {
+	for i, other := range l {
+		if other == item {
+			return append(l[:i], l[i+1:]...)
+		}
+	}
+	return l
 }
 
 func sendToSlack(webhookURL string, message string) {

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/sethlaw/EasyEASM
 go 1.20
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/mattn/go-sqlite3 v1.14.22 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/g0ldencybersec/EasyEASM
+module github.com/sethlaw/EasyEASM
 
 go 1.20
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/active/active.go
+++ b/pkg/active/active.go
@@ -1,9 +1,9 @@
 package active
 
 import (
-	"github.com/g0ldencybersec/EasyEASM/pkg/active/alterx"
-	"github.com/g0ldencybersec/EasyEASM/pkg/active/dnsx"
-	"github.com/g0ldencybersec/EasyEASM/pkg/active/httpx"
+	"github.com/sethlaw/EasyEASM/pkg/active/alterx"
+	"github.com/sethlaw/EasyEASM/pkg/active/dnsx"
+	"github.com/sethlaw/EasyEASM/pkg/active/httpx"
 )
 
 type ActiveRunner struct {

--- a/pkg/active/alterx/alterx.go
+++ b/pkg/active/alterx/alterx.go
@@ -19,7 +19,7 @@ func RunAlterx(domains []string, threads int) []string {
 	err := cmd.Run()
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	cmd = exec.Command("dnsx", "-l", "alterxDomains.txt", "-silent", "-a", "-cname", "-aaaa", "-t", strconv.Itoa(threads))
@@ -29,7 +29,7 @@ func RunAlterx(domains []string, threads int) []string {
 	err = cmd.Run()
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	for _, domain := range strings.Split(out.String(), "\n") {
@@ -49,7 +49,8 @@ func createDomainFile(domains []string) {
 	file, err := os.OpenFile("tempDomains.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
+		return
 	}
 
 	datawriter := bufio.NewWriter(file)

--- a/pkg/active/alterx/alterx.go
+++ b/pkg/active/alterx/alterx.go
@@ -37,8 +37,8 @@ func RunAlterx(domains []string, threads int) []string {
 			results = append(results, domain)
 		}
 	}
-	fmt.Println("ALTERX RESULTS")
-	fmt.Println(results)
+	fmt.Println("ALTERX DOMAINS", len(results))
+	// fmt.Println(results)
 	os.Remove("tempDomains.txt")
 	os.Remove("alterxDomains.txt")
 

--- a/pkg/active/alterx/alterx.go
+++ b/pkg/active/alterx/alterx.go
@@ -11,7 +11,7 @@ import (
 )
 
 func RunAlterx(domains []string, threads int) []string {
-	fmt.Println("Starting permuatation scan!")
+	fmt.Println("  => Starting permuatation scan!")
 	var results []string
 	createDomainFile(domains)
 
@@ -37,7 +37,7 @@ func RunAlterx(domains []string, threads int) []string {
 			results = append(results, domain)
 		}
 	}
-	fmt.Println("ALTERX DOMAINS", len(results))
+	fmt.Println("  => alterx domains: ", len(results))
 	// fmt.Println(results)
 	os.Remove("tempDomains.txt")
 	os.Remove("alterxDomains.txt")

--- a/pkg/active/dnsx/dnsx.go
+++ b/pkg/active/dnsx/dnsx.go
@@ -22,7 +22,7 @@ func RunDnsx(seedDomains []string, wordlist string, threads int) []string {
 			err := cmd.Run()
 
 			if err != nil {
-				panic(err)
+				fmt.Println(err)
 			}
 
 			for _, domain := range strings.Split(out.String(), "\n") {

--- a/pkg/active/dnsx/dnsx.go
+++ b/pkg/active/dnsx/dnsx.go
@@ -10,7 +10,7 @@ import (
 )
 
 func RunDnsx(seedDomains []string, wordlist string, threads int) []string {
-	fmt.Println("Running dnsx Brute force")
+	fmt.Println("Running dnsx brute force")
 	var results []string
 	for _, domain := range seedDomains {
 		if domain != "" {
@@ -34,7 +34,7 @@ func RunDnsx(seedDomains []string, wordlist string, threads int) []string {
 
 	}
 
-	fmt.Println("Total active subdomain results: ", len(results))
+	fmt.Println("Total dnsx brute force results: ", len(results))
 	// fmt.Println(results)
 	os.Remove("tempDomains.txt")
 	return results

--- a/pkg/active/dnsx/dnsx.go
+++ b/pkg/active/dnsx/dnsx.go
@@ -10,7 +10,7 @@ import (
 )
 
 func RunDnsx(seedDomains []string, wordlist string, threads int) []string {
-	fmt.Printf("Runing Bruteforce!")
+	fmt.Println("Running dnsx Brute force")
 	var results []string
 	for _, domain := range seedDomains {
 		if domain != "" {

--- a/pkg/active/dnsx/dnsx.go
+++ b/pkg/active/dnsx/dnsx.go
@@ -34,8 +34,8 @@ func RunDnsx(seedDomains []string, wordlist string, threads int) []string {
 
 	}
 
-	fmt.Println("ACTIVE RESULTS")
-	fmt.Println(results)
+	fmt.Println("Total active subdomain results: ", len(results))
+	// fmt.Println(results)
 	os.Remove("tempDomains.txt")
 	return results
 }

--- a/pkg/active/dnsx/dnsx.go
+++ b/pkg/active/dnsx/dnsx.go
@@ -10,7 +10,7 @@ import (
 )
 
 func RunDnsx(seedDomains []string, wordlist string, threads int) []string {
-	fmt.Println("Running dnsx brute force")
+	fmt.Println("  => Running dnsx")
 	var results []string
 	for _, domain := range seedDomains {
 		if domain != "" {
@@ -34,7 +34,7 @@ func RunDnsx(seedDomains []string, wordlist string, threads int) []string {
 
 	}
 
-	fmt.Println("Total dnsx brute force results: ", len(results))
+	// fmt.Println("  => dnsx results: ", len(results))
 	// fmt.Println(results)
 	os.Remove("tempDomains.txt")
 	return results

--- a/pkg/active/httpx/httpx.go
+++ b/pkg/active/httpx/httpx.go
@@ -13,7 +13,7 @@ func RunHttpx(domains []string) {
 	cmd := exec.Command("httpx", "-l", "tempHttpx.txt", "-silent", "-td", "-csv", "-o", "temp.csv")
 	err := cmd.Run()
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 	fmt.Println("  => httpx run completed")
 	processCSV()
@@ -25,7 +25,7 @@ func writeTempFile(list []string) {
 	file, err := os.OpenFile("tempHttpx.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	datawriter := bufio.NewWriter(file)
@@ -42,7 +42,7 @@ func processCSV() {
 	// Open the CSV file
 	inputFile, err := os.Open("temp.csv")
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 	defer inputFile.Close()
 
@@ -52,7 +52,7 @@ func processCSV() {
 	// Read the whole CSV into memory
 	records, err := reader.ReadAll()
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	// Specify the indices of the columns to keep
@@ -61,7 +61,7 @@ func processCSV() {
 	// Open the output CSV file
 	outputFile, err := os.Create("EasyEASM.csv")
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 	defer outputFile.Close()
 
@@ -77,13 +77,13 @@ func processCSV() {
 			}
 		}
 		if err := writer.Write(filteredRecord); err != nil {
-			panic(err)
+			fmt.Println(err)
 		}
 	}
 
 	// Ensure everything is written to the output file
 	if err := writer.Error(); err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 }

--- a/pkg/active/httpx/httpx.go
+++ b/pkg/active/httpx/httpx.go
@@ -15,7 +15,7 @@ func RunHttpx(domains []string) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Httpx run completed")
+	fmt.Println("Httpx run completed")
 	processCSV()
 	os.Remove("tempHttpx.txt")
 	os.Remove("temp.csv")
@@ -56,7 +56,7 @@ func processCSV() {
 	}
 
 	// Specify the indices of the columns to keep
-	columnsToKeep := []int{0,1,7,8,10,13,17,20,26,27,28,32,33,35,37} // Keeping only the first and third columns (0-indexed)
+	columnsToKeep := []int{0, 1, 7, 8, 10, 11, 12, 17, 20, 26, 27, 28, 32, 33, 35, 37} // Keeping only interesting columns (0-indexed)
 
 	// Open the output CSV file
 	outputFile, err := os.Create("EasyEASM.csv")

--- a/pkg/active/httpx/httpx.go
+++ b/pkg/active/httpx/httpx.go
@@ -15,7 +15,7 @@ func RunHttpx(domains []string) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("Httpx run completed")
+	fmt.Println("  => httpx run completed")
 	processCSV()
 	os.Remove("tempHttpx.txt")
 	os.Remove("temp.csv")

--- a/pkg/passive/amass/amass.go
+++ b/pkg/passive/amass/amass.go
@@ -15,7 +15,7 @@ func RunAmass(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	err := cmd.Run()
 
 	if err != nil {
-		panic(err)
+		fmt.Print(err)
 	}
 	cmd = exec.Command("oam_subs", "-names", "-d", seedDomain)
 	var out bytes.Buffer
@@ -23,7 +23,7 @@ func RunAmass(seedDomain string, results chan string, wg *sync.WaitGroup) {
 
 	err = cmd.Run()
 	if err != nil {
-		panic(err)
+		fmt.Print(err)
 	}
 
 	for _, domain := range strings.Split(out.String(), "\n") {

--- a/pkg/passive/amass/amass.go
+++ b/pkg/passive/amass/amass.go
@@ -10,7 +10,7 @@ import (
 
 func RunAmass(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	fmt.Printf("Running Amass on %s\n", seedDomain)
+	fmt.Printf("    => Running amass on %s\n", seedDomain)
 	cmd := exec.Command("amass", "enum", "--passive", "-nocolor", "-d", seedDomain)
 	err := cmd.Run()
 
@@ -31,5 +31,4 @@ func RunAmass(seedDomain string, results chan string, wg *sync.WaitGroup) {
 			results <- domain
 		}
 	}
-	fmt.Printf("Amass Run completed for %s\n", seedDomain)
 }

--- a/pkg/passive/httpx/httpx.go
+++ b/pkg/passive/httpx/httpx.go
@@ -13,7 +13,7 @@ func RunHttpx(domains []string) {
 	cmd := exec.Command("httpx", "-l", "tempHttpx.txt", "-silent", "-td", "-csv", "-o", "temp.csv")
 	err := cmd.Run()
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 	fmt.Println("  => httpx run completed")
 	processCSV()
@@ -25,7 +25,7 @@ func writeTempFile(list []string) {
 	file, err := os.OpenFile("tempHttpx.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	datawriter := bufio.NewWriter(file)
@@ -42,7 +42,7 @@ func processCSV() {
 	// Open the CSV file
 	inputFile, err := os.Open("temp.csv")
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 	defer inputFile.Close()
 
@@ -52,7 +52,7 @@ func processCSV() {
 	// Read the whole CSV into memory
 	records, err := reader.ReadAll()
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	// Specify the indices of the columns to keep
@@ -61,7 +61,7 @@ func processCSV() {
 	// Open the output CSV file
 	outputFile, err := os.Create("EasyEASM.csv")
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 	defer outputFile.Close()
 
@@ -77,13 +77,15 @@ func processCSV() {
 			}
 		}
 		if err := writer.Write(filteredRecord); err != nil {
-			panic(err)
+			fmt.Println(err)
+			return
 		}
 	}
 
 	// Ensure everything is written to the output file
 	if err := writer.Error(); err != nil {
-		panic(err)
+		fmt.Println(err)
+		return
 	}
 
 }

--- a/pkg/passive/httpx/httpx.go
+++ b/pkg/passive/httpx/httpx.go
@@ -15,7 +15,7 @@ func RunHttpx(domains []string) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("Httpx run completed")
+	fmt.Println("  => httpx run completed")
 	processCSV()
 	os.Remove("tempHttpx.txt")
 	os.Remove("temp.csv")

--- a/pkg/passive/httpx/httpx.go
+++ b/pkg/passive/httpx/httpx.go
@@ -15,7 +15,7 @@ func RunHttpx(domains []string) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Httpx run completed")
+	fmt.Println("Httpx run completed")
 	processCSV()
 	os.Remove("tempHttpx.txt")
 	os.Remove("temp.csv")
@@ -56,7 +56,7 @@ func processCSV() {
 	}
 
 	// Specify the indices of the columns to keep
-	columnsToKeep := []int{0,1,7,8,10,13,17,20,26,27,28,32,33,35,37} // Keeping only the first and third columns (0-indexed)
+	columnsToKeep := []int{0, 1, 7, 8, 10, 11, 12, 17, 20, 26, 27, 28, 32, 33, 35, 37} // Keeping only the first and third columns (0-indexed)
 
 	// Open the output CSV file
 	outputFile, err := os.Create("EasyEASM.csv")

--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/g0ldencybersec/EasyEASM/pkg/passive/amass"
-	"github.com/g0ldencybersec/EasyEASM/pkg/passive/httpx"
-	"github.com/g0ldencybersec/EasyEASM/pkg/passive/subfinder"
+	"github.com/sethlaw/EasyEASM/pkg/passive/amass"
+	"github.com/sethlaw/EasyEASM/pkg/passive/httpx"
+	"github.com/sethlaw/EasyEASM/pkg/passive/subfinder"
 )
 
 type PassiveRunner struct {

--- a/pkg/passive/passive.go
+++ b/pkg/passive/passive.go
@@ -16,13 +16,12 @@ type PassiveRunner struct {
 }
 
 func (r *PassiveRunner) RunPassiveEnum() []string {
-	fmt.Println("Running Passive Sources")
+	fmt.Println("  => Running Passive Sources")
 	var wg sync.WaitGroup
 	sf_results := make(chan string)
 	amass_results := make(chan string)
 	for _, domain := range r.SeedDomains {
 		wg.Add(2)
-		fmt.Printf("Finding domains for %s\n", domain)
 		go subfinder.RunSubfinder(domain, sf_results, &wg)
 		go amass.RunAmass(domain, amass_results, &wg)
 	}

--- a/pkg/passive/subfinder/subfinder.go
+++ b/pkg/passive/subfinder/subfinder.go
@@ -18,7 +18,7 @@ func RunSubfinder(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	err := cmd.Run()
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 
 	for _, domain := range strings.Split(out.String(), "\n") {

--- a/pkg/passive/subfinder/subfinder.go
+++ b/pkg/passive/subfinder/subfinder.go
@@ -10,7 +10,7 @@ import (
 
 func RunSubfinder(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	fmt.Printf("Runing Subfinder on %s\n", seedDomain)
+	fmt.Printf("Running Subfinder on %s\n", seedDomain)
 	cmd := exec.Command("subfinder", "-d", seedDomain, "-silent")
 
 	var out bytes.Buffer

--- a/pkg/passive/subfinder/subfinder.go
+++ b/pkg/passive/subfinder/subfinder.go
@@ -10,7 +10,7 @@ import (
 
 func RunSubfinder(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	fmt.Printf("Running Subfinder on %s\n", seedDomain)
+	fmt.Printf("    => Running subfinder on %s\n", seedDomain)
 	cmd := exec.Command("subfinder", "-d", seedDomain, "-silent")
 
 	var out bytes.Buffer
@@ -26,5 +26,5 @@ func RunSubfinder(seedDomain string, results chan string, wg *sync.WaitGroup) {
 			results <- domain
 		}
 	}
-	fmt.Printf("Subfinder run completed for %s\n", seedDomain)
+	// fmt.Printf("  => subfinder run completed for %s\n", seedDomain)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -44,7 +44,7 @@ func NotifyNewDomainsDiscord(newDomains []string, discordWebhook string) {
 	// Open the CSV file
 	inputFile, err := os.Open("old_EasyEASM.csv")
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
 	}
 	defer inputFile.Close()
 
@@ -69,7 +69,7 @@ func NotifyNewDomainsDiscord(newDomains []string, discordWebhook string) {
 				break
 			} else {
 				// Some other error
-				panic(err)
+				fmt.Println(err)
 			}
 		}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -36,7 +36,7 @@ func NotifyNewDomainsSlack(newDomains []string, slackWebhook string) {
 	reader := csv.NewReader(inputFile)
 
 	// The index of the column you want to extract
-	columnToExtract := 3
+	columnToExtract := 6
 
 	// Slice to hold the values from the specified column
 	var oldDomains []string
@@ -71,6 +71,9 @@ func NotifyNewDomainsSlack(newDomains []string, slackWebhook string) {
 	NewDomainsToAlert := difference(newDomains, oldDomains)
 	OldDomainsToAlert := difference(oldDomains, newDomains)
 
+	fmt.Println("Old domains: ", oldDomains)
+	fmt.Println("New domains: ", NewDomainsToAlert)
+
 	sendToSlack(slackWebhook, fmt.Sprintf("New live domains found: %v", NewDomainsToAlert))
 	sendToSlack(slackWebhook, fmt.Sprintf("Domains that were not to be now longer live: %v", OldDomainsToAlert))
 }
@@ -87,7 +90,7 @@ func NotifyNewDomainsDiscord(newDomains []string, discordWebhook string) {
 	reader := csv.NewReader(inputFile)
 
 	// The index of the column you want to extract
-	columnToExtract := 3
+	columnToExtract := 6
 
 	// Slice to hold the values from the specified column
 	var oldDomains []string
@@ -117,6 +120,8 @@ func NotifyNewDomainsDiscord(newDomains []string, discordWebhook string) {
 	NewDomainsToAlert := difference(newDomains, oldDomains)
 	OldDomainsToAlert := difference(oldDomains, newDomains)
 
+	fmt.Println("Old domains: ", oldDomains)
+	fmt.Println("New domains: ", NewDomainsToAlert)
 	sendToDiscord(discordWebhook, fmt.Sprintf("New live domains found: %v", NewDomainsToAlert))
 	sendToDiscord(discordWebhook, fmt.Sprintf("Domains that were not to be now longer live: %v", OldDomainsToAlert))
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -27,57 +29,15 @@ func RemoveDuplicates(slice []string) []string {
 }
 
 func NotifyNewDomainsSlack(newDomains []string, slackWebhook string) {
-	// Open the CSV file
-	inputFile, err := os.Open("old_EasyEASM.csv")
-	if err != nil {
-		panic(err)
-	}
-	defer inputFile.Close()
 
-	// Create a new CSV reader
-	reader := csv.NewReader(inputFile)
-
-	// The index of the column you want to extract
-	columnToExtract := 6
-
-	// Slice to hold the values from the specified column
-	var oldDomains []string
-
-	// Iterate through the records, extracting the value from the specified column
-	var firstLine bool = true
-	for {
-		if firstLine {
-			reader.Read()
-			firstLine = false
-		}
-		record, err := reader.Read()
-		if err != nil {
-			if err == csv.ErrTrailingComma {
-				// Skip records with trailing commas
-				continue
-			} else if err.Error() == "EOF" {
-				// End of file
-				break
-			} else {
-				// Some other error
-				panic(err)
-			}
-		}
-
-		// Append the value from the specified column if the index is within bounds
-		if columnToExtract < len(record) {
-			oldDomains = append(oldDomains, record[columnToExtract])
-		}
-	}
-
-	NewDomainsToAlert := difference(newDomains, oldDomains)
+	/* NewDomainsToAlert := difference(newDomains, oldDomains)
 	OldDomainsToAlert := difference(oldDomains, newDomains)
 
 	fmt.Println("Old domains: ", oldDomains)
-	fmt.Println("New domains: ", NewDomainsToAlert)
+	fmt.Println("New domains: ", NewDomainsToAlert) */
 
-	sendToSlack(slackWebhook, fmt.Sprintf("New live domains found: %v", NewDomainsToAlert))
-	sendToSlack(slackWebhook, fmt.Sprintf("Domains that were not to be now longer live: %v", OldDomainsToAlert))
+	sendToSlack(slackWebhook, fmt.Sprintf("New domains found: %v", newDomains))
+	//sendToSlack(slackWebhook, fmt.Sprintf("Domains that were not to be now longer live: %v", OldDomainsToAlert))
 }
 
 func NotifyNewDomainsDiscord(newDomains []string, discordWebhook string) {
@@ -233,5 +193,105 @@ func installGoTool(name string, path string) {
 		log.Fatalf("An error occurred while installing the package: %s\n%s", err, cmdOutput)
 	}
 
-	log.Printf("Successfully installed the %s package: %s", name, packagePath)
+	log.Printf("Successfully installed the package: %s", packagePath)
+}
+
+func setupDB() {
+	file, err := os.Create("easyeasm.db")
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	file.Close()
+
+	sqliteDatabase, _ := sql.Open("sqlite3", "./easyeasm.db") // Open the created SQLite File
+	defer sqliteDatabase.Close()                              // Defer Closing the database
+	createTable(sqliteDatabase)                               // Create Database Tables
+}
+
+func createTable(db *sql.DB) {
+	createDomainTable := `CREATE TABLE domains (
+		"id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,		
+		"domain" TEXT,
+		"active" BOOLEAN,
+		"live" BOOLEAN,
+		"first_seen" TEXT,
+		"last_seen" TEXT		
+	  );`
+
+	statement, err := db.Prepare(createDomainTable)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	statement.Exec()
+}
+
+func getDomains(db *sql.DB) []string {
+	rows, err := db.Query("SELECT domain FROM domains")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	var domains []string
+	for rows.Next() {
+		var domain string
+		rows.Scan(&domain)
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func getActiveDomains(db *sql.DB) []string {
+	rows, err := db.Query("SELECT domain FROM domains WHERE active = 1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	var domains []string
+	for rows.Next() {
+		var domain string
+		rows.Scan(&domain)
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func getLiveDomains(db *sql.DB) []string {
+	rows, err := db.Query("SELECT domain FROM domains WHERE live = 1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	var domains []string
+	for rows.Next() {
+		var domain string
+		rows.Scan(&domain)
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func insertDomain(db *sql.DB, domain string) {
+	insertSQL := `INSERT INTO domains(domain, active, live, first_seen, last_seen) VALUES (?, ?, ?, ?, ?)`
+	statement, err := db.Prepare(insertSQL)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	var now = time.Now()
+	_, err = statement.Exec(domain, 1, 0, now, now)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+}
+
+func updateDomain(db *sql.DB, domain string, live bool) {
+	updateSQL := `UPDATE domains SET live = ?, last_seen = ? WHERE domain = ?`
+	statement, err := db.Prepare(updateSQL)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	var now = time.Now()
+	_, err = statement.Exec(live, now, domain)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -10,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -235,105 +233,5 @@ func installGoTool(name string, path string) {
 		log.Fatalf("An error occurred while installing the package: %s\n%s", err, cmdOutput)
 	}
 
-	log.Printf("Successfully installed the package: %s", packagePath)
-}
-
-func setupDB() {
-	file, err := os.Create("easyeasm.db")
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	file.Close()
-
-	sqliteDatabase, _ := sql.Open("sqlite3", "./sqlite-database.db") // Open the created SQLite File
-	defer sqliteDatabase.Close()                                     // Defer Closing the database
-	createTable(sqliteDatabase)                                      // Create Database Tables
-}
-
-func createTable(db *sql.DB) {
-	createDomainTable := `CREATE TABLE domains (
-		"id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,		
-		"domain" TEXT,
-		"active" BOOLEAN,
-		"live" BOOLEAN,
-		"first_seen" TEXT,
-		"last_seen" TEXT		
-	  );`
-
-	statement, err := db.Prepare(createDomainTable)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	statement.Exec()
-}
-
-func getDomains(db *sql.DB) []string {
-	rows, err := db.Query("SELECT domain FROM domains")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer rows.Close()
-	var domains []string
-	for rows.Next() {
-		var domain string
-		rows.Scan(&domain)
-		domains = append(domains, domain)
-	}
-	return domains
-}
-
-func getActiveDomains(db *sql.DB) []string {
-	rows, err := db.Query("SELECT domain FROM domains WHERE active = 1")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer rows.Close()
-	var domains []string
-	for rows.Next() {
-		var domain string
-		rows.Scan(&domain)
-		domains = append(domains, domain)
-	}
-	return domains
-}
-
-func getLiveDomains(db *sql.DB) []string {
-	rows, err := db.Query("SELECT domain FROM domains WHERE live = 1")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer rows.Close()
-	var domains []string
-	for rows.Next() {
-		var domain string
-		rows.Scan(&domain)
-		domains = append(domains, domain)
-	}
-	return domains
-}
-
-func insertDomain(db *sql.DB, domain string) {
-	insertSQL := `INSERT INTO domains(domain, active, live, first_seen, last_seen) VALUES (?, ?, ?, ?, ?)`
-	statement, err := db.Prepare(insertSQL)
-	if err != nil {
-		log.Fatalln(err.Error())
-	}
-	var now = time.Now()
-	_, err = statement.Exec(domain, 0, 1, now, now)
-	if err != nil {
-		log.Fatalln(err.Error())
-	}
-}
-
-func updateDomain(db *sql.DB, domain string, live bool) {
-	updateSQL := `UPDATE domains SET live = ?, last_seen = ? WHERE domain = ?`
-	statement, err := db.Prepare(updateSQL)
-	if err != nil {
-		log.Fatalln(err.Error())
-	}
-	var now = time.Now()
-	_, err = statement.Exec(live, now, domain)
-	if err != nil {
-		log.Fatalln(err.Error())
-	}
+	log.Printf("Successfully installed the %s package: %s", name, packagePath)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,7 +42,12 @@ func NotifyNewDomainsSlack(newDomains []string, slackWebhook string) {
 	var oldDomains []string
 
 	// Iterate through the records, extracting the value from the specified column
+	var firstLine bool = true
 	for {
+		if firstLine {
+			reader.Read()
+			firstLine = false
+		}
 		record, err := reader.Read()
 		if err != nil {
 			if err == csv.ErrTrailingComma {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -319,7 +319,7 @@ func insertDomain(db *sql.DB, domain string) {
 		log.Fatalln(err.Error())
 	}
 	var now = time.Now()
-	_, err = statement.Exec(domain, 1, 0, now, now)
+	_, err = statement.Exec(domain, 0, 1, now, now)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,9 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func RemoveDuplicates(slice []string) []string {
@@ -232,4 +236,104 @@ func installGoTool(name string, path string) {
 	}
 
 	log.Printf("Successfully installed the package: %s", packagePath)
+}
+
+func setupDB() {
+	file, err := os.Create("easyeasm.db")
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	file.Close()
+
+	sqliteDatabase, _ := sql.Open("sqlite3", "./sqlite-database.db") // Open the created SQLite File
+	defer sqliteDatabase.Close()                                     // Defer Closing the database
+	createTable(sqliteDatabase)                                      // Create Database Tables
+}
+
+func createTable(db *sql.DB) {
+	createDomainTable := `CREATE TABLE domains (
+		"id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,		
+		"domain" TEXT,
+		"active" BOOLEAN,
+		"live" BOOLEAN,
+		"first_seen" TEXT,
+		"last_seen" TEXT		
+	  );`
+
+	statement, err := db.Prepare(createDomainTable)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	statement.Exec()
+}
+
+func getDomains(db *sql.DB) []string {
+	rows, err := db.Query("SELECT domain FROM domains")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	var domains []string
+	for rows.Next() {
+		var domain string
+		rows.Scan(&domain)
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func getActiveDomains(db *sql.DB) []string {
+	rows, err := db.Query("SELECT domain FROM domains WHERE active = 1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	var domains []string
+	for rows.Next() {
+		var domain string
+		rows.Scan(&domain)
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func getLiveDomains(db *sql.DB) []string {
+	rows, err := db.Query("SELECT domain FROM domains WHERE live = 1")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	var domains []string
+	for rows.Next() {
+		var domain string
+		rows.Scan(&domain)
+		domains = append(domains, domain)
+	}
+	return domains
+}
+
+func insertDomain(db *sql.DB, domain string) {
+	insertSQL := `INSERT INTO domains(domain, active, live, first_seen, last_seen) VALUES (?, ?, ?, ?, ?)`
+	statement, err := db.Prepare(insertSQL)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	var now = time.Now()
+	_, err = statement.Exec(domain, 1, 0, now, now)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+}
+
+func updateDomain(db *sql.DB, domain string, live bool) {
+	updateSQL := `UPDATE domains SET live = ?, last_seen = ? WHERE domain = ?`
+	statement, err := db.Prepare(updateSQL)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	var now = time.Now()
+	_, err = statement.Exec(live, now, domain)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
 }


### PR DESCRIPTION
Update utils to ignore the headers of the CSV file in tracking historical domains. Mainly reduce noise in the slack hooks when the tool reports that `sni` is a domain that no longer exists.