### PR TITLE
Resolve conflicts between command execution and system commands.

### DIFF
--- a/pkg/passive/amass/amass.go
+++ b/pkg/passive/amass/amass.go
@@ -6,18 +6,21 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/g0ldencybersec/EasyEASM/pkg/utils"
 )
 
 func RunAmass(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	fmt.Printf("Running Amass on %s\n", seedDomain)
-	cmd := exec.Command("amass", "enum", "--passive", "-nocolor", "-d", seedDomain)
+	binPath := utils.GetGoEnvPathBin()
+	cmd := exec.Command(binPath+"/amass", "enum", "--passive", "-nocolor", "-d", seedDomain)
 	err := cmd.Run()
 
 	if err != nil {
 		panic(err)
 	}
-	cmd = exec.Command("oam_subs", "-names", "-d", seedDomain)
+	cmd = exec.Command(binPath+"/oam_subs", "-names", "-d", seedDomain)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 

--- a/pkg/passive/httpx/httpx.go
+++ b/pkg/passive/httpx/httpx.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/g0ldencybersec/EasyEASM/pkg/utils"
 )
 
 func RunHttpx(domains []string) {
 	writeTempFile(domains)
-	cmd := exec.Command("httpx", "-l", "tempHttpx.txt", "-silent", "-td", "-csv", "-o", "temp.csv")
+	binPath := utils.GetGoEnvPathBin()
+	cmd := exec.Command(binPath+"/httpx", "-l", "tempHttpx.txt", "-silent", "-td", "-csv", "-o", "temp.csv")
 	err := cmd.Run()
 	if err != nil {
 		panic(err)
@@ -56,7 +59,7 @@ func processCSV() {
 	}
 
 	// Specify the indices of the columns to keep
-	columnsToKeep := []int{0,1,7,8,10,13,17,20,26,27,28,32,33,35,37} // Keeping only the first and third columns (0-indexed)
+	columnsToKeep := []int{0, 1, 7, 8, 10, 13, 17, 20, 26, 27, 28, 32, 33, 35, 37} // Keeping only the first and third columns (0-indexed)
 
 	// Open the output CSV file
 	outputFile, err := os.Create("EasyEASM.csv")

--- a/pkg/passive/subfinder/subfinder.go
+++ b/pkg/passive/subfinder/subfinder.go
@@ -6,13 +6,15 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/g0ldencybersec/EasyEASM/pkg/utils"
 )
 
 func RunSubfinder(seedDomain string, results chan string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	fmt.Printf("Runing Subfinder on %s\n", seedDomain)
-	cmd := exec.Command("subfinder", "-d", seedDomain, "-silent")
-
+	binPath := utils.GetGoEnvPathBin()
+	cmd := exec.Command(binPath+"/subfinder", "-d", seedDomain, "-silent")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func RemoveDuplicates(slice []string) []string {
@@ -194,7 +195,7 @@ func InstallTools() {
 		"subfinder": "github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest",
 	} {
 		if !checkTool(name) {
-			installGoTool(name, path)
+			installGoTool(path)
 		}
 	}
 
@@ -202,7 +203,11 @@ func InstallTools() {
 }
 
 func checkTool(name string) bool {
-	_, err := exec.LookPath(name)
+	binPath := GetGoEnvPathBin()
+	// Construct the executable file path for the tool.
+	toolPath := filepath.Join(binPath, name)
+
+	_, err := os.Stat(toolPath)
 	if err != nil {
 		fmt.Printf("%s is not installed\n", name)
 		return false
@@ -211,10 +216,9 @@ func checkTool(name string) bool {
 	return true
 }
 
-func installGoTool(name string, path string) {
+func installGoTool(path string) {
 	// Replace this with the package you want to install
 	packagePath := path
-
 	cmd := exec.Command("go", "install", packagePath)
 	cmdOutput, err := cmd.CombinedOutput()
 	if err != nil {
@@ -222,4 +226,14 @@ func installGoTool(name string, path string) {
 	}
 
 	log.Printf("Successfully installed the package: %s", packagePath)
+}
+
+func GetGoEnvPathBin() string {
+	// Get the path of the bin directory from the Go environment variables.
+	goPath := os.Getenv("GOPATH")
+	if goPath == "" {
+		goPath = filepath.Join(os.Getenv("HOME"), "go")
+	}
+	binPath := filepath.Join(goPath, "bin")
+	return binPath
 }


### PR DESCRIPTION
Fix some issues:

1. During project initialization, it's necessary to check if the required tools are installed in the local environment. The check should inspect whether the necessary tools are present in the `bin` directory of `go env`, rather than simply checking for their existence in the bash commands. If there are similarly named tools in the bash commands but they are not the same, it could lead to installation being ignored, causing errors in subsequent execution.
2. When executing commands in the `passive` package, ensure the use of tools from the `bin` directory of `go env` to avoid conflicts with similarly named tools that come with the system."